### PR TITLE
Update RDF::LDP to 0.5.0

### DIFF
--- a/derby.gemspec
+++ b/derby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version      = '>= 2.0.0'
   gem.requirements               = []
 
-  gem.add_runtime_dependency     'rdf-ldp', '~> 0.4'
+  gem.add_runtime_dependency     'rdf-ldp', '~> 0.5'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rdf-spec',    '~> 1.1', '>= 1.1.13'


### PR DESCRIPTION
RDF::LDP 0.4.0 is a broken build due to: https://github.com/ruby-rdf/rdf-ldp/issues/42.

This upgrades to the fixed 0.5.0.

Closes #8.
