### PR TITLE
Upgrade to RDF::LDP 0.5.1

### DIFF
--- a/derby.gemspec
+++ b/derby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version      = '>= 2.0.0'
   gem.requirements               = []
 
-  gem.add_runtime_dependency     'rdf-ldp', '~> 0.5'
+  gem.add_runtime_dependency     'rdf-ldp', '~> 0.5', '>=0.5.1'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rdf-spec',    '~> 1.1', '>= 1.1.13'


### PR DESCRIPTION
Releases before 0.5.1 have a bug that breaks ldp:insertedContentRelation in Indirect Containers.

When gets merged, we should cut a release. It might be worth making it `0.1.0`.
