### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     if: "contains(github.event.commits[0].message, '[ci skip]') == false"
     runs-on: ubuntu-latest
+    env:
+      CI: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
+      ALLOW_FAILURES: ${{ endsWith(matrix.ruby, 'head') }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,4 +33,4 @@ jobs:
       - name: Install dependencies
         run: bundle install --jobs 4 --retry 3
       - name: Run tests
-        run: ruby --version; bundle exec rspec spec
+        run: ruby --version; bundle exec rspec spec || $ALLOW_FAILURES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ develop ]
+  workflow_dispatch:
+jobs:
+  tests:
+    name: Ruby ${{ matrix.ruby }}
+    if: "contains(github.event.commits[0].message, '[ci skip]') == false"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 2.6
+          - 2.7
+          - 3.0
+          - 3.1
+          - ruby-head
+          - jruby
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+      - name: Run tests
+        run: ruby --version; bundle exec rspec spec

--- a/derby.gemspec
+++ b/derby.gemspec
@@ -18,18 +18,18 @@ Gem::Specification.new do |gem|
   gem.files              = %w(AUTHORS CHANGELOG.md README.md LICENSE VERSION) +
                            Dir.glob('lib/**/*.rb') + Dir.glob('app/**/*.rb')
   gem.bindir             = %q(exe)
-  gem.executables        = %w(derby-ldp)
-  gem.default_executable = gem.executables.first
+  #gem.executables        = %w(derby-ldp)
+  #gem.default_executable = gem.executables.first
   gem.require_paths      = %w(lib)
-  gem.has_rdoc           = false
+  #gem.has_rdoc           = false
 
-  gem.required_ruby_version      = '>= 2.0.0'
+  gem.required_ruby_version      = '>= 2.6'
   gem.requirements               = []
 
-  gem.add_runtime_dependency     'rdf-ldp',     '~> 1.0.1'
+  gem.add_runtime_dependency     'rdf-ldp',     '~> 2.1'
 
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'rdf-spec',    '~> 2.0'
+  gem.add_development_dependency 'rdf-spec',    '~> 3.0'
   gem.add_development_dependency 'rspec',       '~> 3.0'
   gem.add_development_dependency 'rack-test',   '~> 0.6'
   gem.add_development_dependency 'yard',        '~> 0.8'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ RSpec.configure do |config|
   config.include(RDF::Spec::Matchers)
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
+  config.filter_run_excluding integration: ENV['CI']
 end
 
 Encoding.default_external = Encoding::UTF_8


### PR DESCRIPTION
* Comment out some obsolete gemspec entries.
* Minimum Ruby version to 2.6.
* Use rdf-ldp ~> 2.1 (and rdf-spec ~> 3.0)
* Do Continuous Integration using GitHub actions. Note that future changes to refinements mean allowing failure on ruby-head.

These changes are primarily motivated to update LDP dependency conflicts.

cc/@no-reply